### PR TITLE
Add passwordless auth by LDAP id

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ authKeyAlias=auth
 
 # Eris
 eris.chain.url=http://someHostname:1337
+
+# Biometric Auth
+biometric.auth.client_id=biometric_app
+# Access SpEL - e.g. "permitAll()", "hasIpAddress('X.X.X.X')"
+biometric.auth.access=hasIpAddress('127.0.0.1')
 ```
 
 ### Step 4: Add logback configuration

--- a/src/main/java/com/softjourn/coin/auth/config/AuthConfiguration.java
+++ b/src/main/java/com/softjourn/coin/auth/config/AuthConfiguration.java
@@ -142,11 +142,16 @@ public class AuthConfiguration {
     @Configuration
     @EnableResourceServer
     public static class OAuthResourceServer extends ResourceServerConfigurerAdapter {
+
+        @Value("${biometric.auth.access}")
+        private String BIOMETRIC_SERVICE_ACCESS;
+
         @Override
         public void configure(HttpSecurity http) throws Exception {
             http
                     .authorizeRequests()
                     .antMatchers("/login").permitAll()
+                    .antMatchers("/login/passwordless/**").access(BIOMETRIC_SERVICE_ACCESS)
                     .antMatchers("/v1/admin/**").hasAnyRole("SUPER_ADMIN", "USER_MANAGER")
                     .antMatchers("/v1/users/**").authenticated()
                     .antMatchers("/oauth/token/revoke").authenticated()

--- a/src/main/java/com/softjourn/coin/auth/controller/LoginController.java
+++ b/src/main/java/com/softjourn/coin/auth/controller/LoginController.java
@@ -1,20 +1,101 @@
 package com.softjourn.coin.auth.controller;
 
-
+import com.softjourn.coin.auth.exception.LDAPNotFoundException;
+import com.softjourn.coin.auth.service.ILdapService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.provider.AuthorizationRequest;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.token.AuthorizationServerTokenServices;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.stream.Collectors;
 
 @Controller
 public class LoginController {
 
-    @RequestMapping(value="/login", method = RequestMethod.GET)
+    @Value("${biometric.auth.client_id}")
+    private String BIOMETRIC_AUTH_CLIENT_ID;
+
+    private final ILdapService ldapService;
+    private final AuthorizationServerTokenServices tokenStore;
+    private final ClientDetailsService clientDetailsService;
+
+    @Autowired
+    public LoginController(ILdapService ldapService,
+                           AuthorizationServerTokenServices tokenStore,
+                           ClientDetailsService clientDetailsService) {
+        this.ldapService = ldapService;
+        this.tokenStore = tokenStore;
+        this.clientDetailsService = clientDetailsService;
+    }
+
+    @RequestMapping(value = "/login", method = RequestMethod.GET)
     public String login(Model model, @RequestParam(required = false) String error) {
-        if(error != null)
+        if (error != null)
             model.addAttribute("error", 1);
         return "login";
+    }
+
+    @PostMapping("/login/passwordless/{ldapId:.+}")
+    public ResponseEntity<OAuth2AccessToken> passwordlessLogin(@RequestHeader("X-CLIENT-SECRET") String clientSecret,
+                                                               @PathVariable("ldapId") String ldapId) {
+        ClientDetails details = clientDetailsService.loadClientByClientId(BIOMETRIC_AUTH_CLIENT_ID);
+
+        if (!clientSecret.equals(details.getClientSecret())) {
+            throw new AccessDeniedException(null);
+        }
+
+        final com.softjourn.coin.auth.entity.User user = ldapService.getUser(ldapId);
+
+        if (user == null) {
+            throw new LDAPNotFoundException(ldapId);
+        }
+
+        final AuthorizationRequest authorizationRequest = new AuthorizationRequest();
+
+        authorizationRequest.setClientId(BIOMETRIC_AUTH_CLIENT_ID);
+        authorizationRequest.setApproved(true);
+        authorizationRequest.setAuthorities(user.getAuthorities()
+                .stream()
+                .map(i -> new SimpleGrantedAuthority(i.getAuthority()))
+                .collect(Collectors.toSet()));
+
+        final User userPrincipal =
+                new User(user.getLdapId(), "", true, true, true, true, authorizationRequest.getAuthorities());
+
+        final UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(userPrincipal, null, authorizationRequest.getAuthorities());
+
+        final OAuth2Authentication authentication =
+                new OAuth2Authentication(authorizationRequest.createOAuth2Request(), authenticationToken);
+
+        authentication.setAuthenticated(true);
+
+        final OAuth2AccessToken accessToken = tokenStore.createAccessToken(authentication);
+
+        return new ResponseEntity<>(accessToken, HttpStatus.OK);
+    }
+
+    @ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "LDAP id not found")
+    @ExceptionHandler(LDAPNotFoundException.class)
+    public void wrongLdapId() {
+    }
+
+    @ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Incorrect client secret")
+    @ExceptionHandler(AccessDeniedException.class)
+    public void forbidden() {
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,6 @@ super.roles=ROLE_SUPER_ADMIN
 common.roles=ROLE_BILLING,ROLE_INVENTORY,ROLE_USER_MANAGER
 
 logging.config=file:${HOME}/.auth/logback.xml
+
+# Eris
+eris.chain.url=http://localhost:1337

--- a/src/main/resources/db/migration/V3__Add_biometric_client.sql
+++ b/src/main/resources/db/migration/V3__Add_biometric_client.sql
@@ -1,0 +1,3 @@
+-- Add biometric auth client. Note: client_secret should be changed in production environment!
+INSERT INTO `oauth_client_details` (`client_id`, `resource_ids`, `client_secret`, `scope`, `authorized_grant_types`, `web_server_redirect_uri`, `authorities`, `access_token_validity`, `refresh_token_validity`, `additional_information`, `autoapprove`) VALUES
+  ('biometric_app', NULL, 'supersecret', 'read,write', 'authorization_code,refresh_token', 'https://sjcoins.testing.softjourn.if.ua/vending/sso', 'ROLE_CLIENT', 6000000, 9000000, NULL, 'true');

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -13,6 +13,9 @@ authKeyStorePass=asdfgqwert
 authKeyMasterPass=zxcvbasdfg
 authKeyAlias=testkey
 
+biometric.auth.access=hasIpAddress('127.0.0.1')
+biometric.auth.client_id=biometric_app
+
 # Eris
 eris.chain.url=http://localhost:1337
 


### PR DESCRIPTION
Added initial implementation for passwordless authorization (only by LDAP ID) required for "authorization by face" functionality.

> For now, the endpoint is secured only by client-secret and access is restricted to a certain list of IP addresses